### PR TITLE
Tonhub-connect 방식으로 payment 수정

### DIFF
--- a/bot-server/src/ton/dtos/ton.dto.ts
+++ b/bot-server/src/ton/dtos/ton.dto.ts
@@ -1,19 +1,13 @@
 import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
 import { Address } from 'ton-core';
+import { TonhubCreatedSession, TonhubWalletConfig } from 'ton-x';
 
-export class TransactionReq {
-  @IsString()
-  @IsNotEmpty()
-  address: Address;
-
-  @IsNumber()
-  @IsNotEmpty()
-  amount: number;
-
-  @IsString()
-  @IsNotEmpty()
-  comment: string;
-}
+type TransactionStatus =
+  | 'rejected'
+  | 'expired'
+  | 'invalid_session'
+  | 'success'
+  | 'unknown';
 
 export class GetAllNFTReq {
   @IsString()
@@ -22,15 +16,15 @@ export class GetAllNFTReq {
 }
 
 export class ConfirmWalletSessionReq {
-  @IsString()
   @IsNotEmpty()
-  sessionId: string;
+  session: TonhubCreatedSession;
 }
 
-export class TransactionDto {
-  address: Address;
-  amount: number;
-  comment: string;
+export class PaymentWalletSessionReq {
+  @IsNotEmpty()
+  session: TonhubCreatedSession;
+  @IsNotEmpty()
+  wallet: TonhubWalletConfig;
 }
 
 export class GetAllNFTDto {
@@ -38,15 +32,12 @@ export class GetAllNFTDto {
 }
 
 export class ConfirmWalletSessionDto {
-  sessionId: string;
+  session: TonhubCreatedSession;
 }
 
-export class VerifyRes {
-  isVerified: boolean;
-}
-
-export class LinkRes {
-  links: string[];
+export class PaymentWalletSessionDto {
+  session: TonhubCreatedSession;
+  wallet: TonhubWalletConfig;
 }
 
 export class GetAllNFTRes {
@@ -54,11 +45,14 @@ export class GetAllNFTRes {
 }
 
 export class CreateWalletSessionRes {
-  sessionId: string;
-  sessionSeed: string;
-  sessionLink: string;
+  session: TonhubCreatedSession;
 }
 
 export class ConfirmWalletSessionRes {
-  walletAddress: string;
+  wallet: TonhubWalletConfig;
+}
+
+export class PaymentWalletSessionRes {
+  status: TransactionStatus;
+  message?: string;
 }

--- a/bot-server/src/ton/ton.controller.ts
+++ b/bot-server/src/ton/ton.controller.ts
@@ -9,10 +9,9 @@ import {
   GetAllNFTDto,
   GetAllNFTReq,
   GetAllNFTRes,
-  LinkRes,
-  TransactionDto,
-  TransactionReq,
-  VerifyRes,
+  PaymentWalletSessionDto,
+  PaymentWalletSessionReq,
+  PaymentWalletSessionRes,
 } from './dtos/ton.dto';
 
 @Controller('ton')
@@ -32,18 +31,12 @@ export class TonController {
     return this.tonService.confirmWalletSession(reqDto);
   }
 
-  @Get('verify')
-  async verifyTransactionExistance(
-    @Body() req: TransactionReq,
-  ): Promise<VerifyRes> {
-    const reqDto = Object.assign(new TransactionDto(), req);
-    return this.tonService.verifyTransaction(reqDto);
-  }
-
-  @Get('link')
-  generatePayLink(@Body() req: TransactionReq): LinkRes {
-    const reqDto = Object.assign(new TransactionDto(), req);
-    return this.tonService.generatePayLink(reqDto);
+  @Get('paymentSession')
+  async paymentWalletSession(
+    @Body() req: PaymentWalletSessionReq,
+  ): Promise<PaymentWalletSessionRes> {
+    const reqDto = Object.assign(new PaymentWalletSessionDto(), req);
+    return this.tonService.paymentWalletSession(reqDto);
   }
 
   @Get('allNFT')


### PR DESCRIPTION
### 변경사항

- Payment 방식을 **Tonhub-connect 방식**으로 변경
     - 기존 방식: 서버에서 결제 링크 생성하여 봇에서 노출 -> 링크를 클릭하여 결제 -> 서버에서 `verifyTransaction` 실행하여 검증
     - 수정된 방식: 서버에서 바로 지갑으로 결제 요청 전송 -> 사용자가 지갑 앱에서 결제 -> 서버에서 결제 결과 수신하여 반환
- `createSession`, `confirmSession` dto 수정
     - `createSession`은 Session 객체(`TonhubCreatedSession` 타입)를 반환
     - `confirmSession`은 Session 객체를 request로 받아, Wallet 객체(`TonhubWalletConfig` 타입)을 반환
     - 두 함수를 콜하여 생성한 Session 객체, Wallet 객체를 `paymentSession`의 request로 입력
     
 @youseop @jewerlykim 한번 테스트해보시고 이상 없으면 머지하면 될 것 같아요! 궁금한 것 있으시면 질문주세요~!